### PR TITLE
Handle text blocks in tables

### DIFF
--- a/man2fhtml
+++ b/man2fhtml
@@ -353,6 +353,16 @@ sub table {
     $out .= "<tr>";
     foreach (split $separator, $_) {
       s/^\s*//; s/\s*$//;
+      if ($_ eq 'T{') {
+	  my @lines;
+	  while (my $l = <>) {
+	      $l =~ s/^\s*//;
+	      $l =~ s/\s*$//;
+	      last if ($l eq 'T}');
+	      push(@lines, $l);
+	  }
+	  $_ = join("\n", @lines);
+      }
 
       my $fmt = shift @format;
       $_ = "\\fB$_" if $fmt =~ /b/;


### PR DESCRIPTION
Make man2fhtml understand the [tbl](https://linux.die.net/man/1/tbl) `T{ ... T}` text block syntax.
This syntax is needed to get the correct line wrapping when processing man pages with groff.  Handle by grouping lines
until the closing bracket is found.  In this implementation, the opening bracket should be the last item on its line and the closing one should be on its own.
