### PR TITLE
Prevent double-conversion of \(rs when followed by (

### DIFF
--- a/man2fhtml
+++ b/man2fhtml
@@ -140,7 +140,7 @@ my %special = (
     an => '&#x23AF;',
     # Lines
     ba => '|', br => '&boxv;', ul => '_', rn => '&oline;', ru => '_',
-    bb => '&brvbar;', sl => '/', rs => '\\',
+    bb => '&brvbar;', sl => '/', rs => '&bsol;',
     # Text markers
     ci => '&#x25CB;', bu => '&bull;', dd => '&Dagger;', dg => '&dagger;',
     lz => '&loz;', sq => '&squ;', ps => '&para;', sc => '&sect;',


### PR DESCRIPTION
Found when processing `'\(rs(.AccessKeyId)'`.  Converting `\(rs` to `&bsol;` prevents the first conversion result from being interpreted as another escape sequence.